### PR TITLE
Fixed QueryBuilder join method

### DIFF
--- a/DaoCore/src/main/java/org/greenrobot/greendao/query/QueryBuilder.java
+++ b/DaoCore/src/main/java/org/greenrobot/greendao/query/QueryBuilder.java
@@ -199,7 +199,7 @@ public class QueryBuilder<T> {
      * as the source for the new join to add. In this way, it is possible to compose complex "join of joins" across
      * several entities if required.
      */
-    public <J> Join<T, J> join(Join<?, T> sourceJoin, Property sourceProperty, Class<J> destinationEntityClass,
+    public <J> Join<T, J> join(Join<T, ?> sourceJoin, Property sourceProperty, Class<J> destinationEntityClass,
                                Property destinationProperty) {
         AbstractDao<J, ?> destinationDao = (AbstractDao<J, ?>) dao.getSession().getDao(destinationEntityClass);
         return addJoin(sourceJoin.tablePrefix, sourceProperty, destinationDao, destinationProperty);


### PR DESCRIPTION
Chained join cannot be performed with the method signature :
public <J> Join<T, J> join(Join<?, T> sourceJoin ...

Fix is :
public <J> Join<T, J> join(Join<T, ?> sourceJoin